### PR TITLE
Implement parsing `/proc/net/{tcp,udp}`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ repository = "https://github.com/nathansizemore/linux-stats"
 
 [dependencies]
 rustc-serialize = "^0.3"
+enum_primitive = "0.1.1"
+num = "0.1.36"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ enum_from_primitive! {
 pub enum SocketTimerState {
     // TODO: other timer states, timeout
     Inactive,
-    Active
+    Active(u64)
 }
 
 /// Represents a line (socket) in output of `cat /proc/net/{tcp,udp}`
@@ -567,7 +567,7 @@ fn to_net_socket(line: &str) -> Socket {
         rx_queue: u64::from_str_radix(queues[1], 16).unwrap(),
         timer: match timer[0].parse::<u8>().unwrap() {
             0 => SocketTimerState::Inactive,
-            _ => SocketTimerState::Active
+            _ => SocketTimerState::Active(u64::from_str_radix(timer[1], 16).unwrap()),
         },
         uid: uid,
         inode: inode
@@ -655,7 +655,7 @@ fn test_to_ipaddr() {
 
 #[test]
 fn test_to_net_socket() {
-    let sock = to_net_socket("  49: 0100007F:1132 5B41EE2E:0050 0A 0000000A:00000002 00:00000000 00000000  1001        0 2796814 1 ffff938ed0741080 20 4 29 10 -1");
+    let sock = to_net_socket("  49: 0100007F:1132 5B41EE2E:0050 0A 0000000A:00000002 01:0000000B 00000000  1001        0 2796814 1 ffff938ed0741080 20 4 29 10 -1");
     assert_eq!(sock.local_address.octets(), [127, 0, 0, 1]);
     assert_eq!(sock.local_port, 4402);
     assert_eq!(sock.remote_address.octets(), [46, 238, 65, 91]);
@@ -663,7 +663,7 @@ fn test_to_net_socket() {
     assert_eq!(sock.state, SocketState::Listen);
     assert_eq!(sock.tx_queue, 0xA);
     assert_eq!(sock.rx_queue, 2);
-    assert_eq!(sock.timer, SocketTimerState::Inactive);
+    assert_eq!(sock.timer, SocketTimerState::Active(0xB));
     assert_eq!(sock.uid, 1001);
     assert_eq!(sock.inode, 2796814);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -559,12 +559,12 @@ fn to_net_socket(line: &str) -> Socket {
     Socket {
         sl: sl,
         local_address: to_ipaddr(local[0]),
-        local_port: to_port(local[1]),
+        local_port: u16::from_str_radix(local[1], 16).unwrap(),
         remote_address: to_ipaddr(remote[0]),
-        remote_port: to_port(remote[1]),
+        remote_port: u16::from_str_radix(remote[1], 16).unwrap(),
         state: SocketState::from_u8(state).unwrap(),
-        tx_queue: queues[0].parse::<u64>().unwrap(),
-        rx_queue: queues[1].parse::<u64>().unwrap(),
+        tx_queue: u64::from_str_radix(queues[0], 16).unwrap(),
+        rx_queue: u64::from_str_radix(queues[1], 16).unwrap(),
         timer: match timer[0].parse::<u8>().unwrap() {
             0 => SocketTimerState::Inactive,
             _ => SocketTimerState::Active
@@ -572,11 +572,6 @@ fn to_net_socket(line: &str) -> Socket {
         uid: uid,
         inode: inode
     }
-}
-
-fn to_port(hex: &str) -> u16 {
-    let bytes = hex.from_hex().unwrap();
-    (bytes[0] as u16 * 256) + bytes[1] as u16
 }
 
 fn to_ipaddr(hex: &str) -> Ipv4Addr {
@@ -659,19 +654,14 @@ fn test_to_ipaddr() {
 }
 
 #[test]
-fn test_to_port() {
-    assert_eq!(to_port("0535"), 1333);
-}
-
-#[test]
 fn test_to_net_socket() {
-    let sock = to_net_socket("  49: 0100007F:1132 5B41EE2E:0050 0A 00000001:00000002 00:00000000 00000000  1001        0 2796814 1 ffff938ed0741080 20 4 29 10 -1");
+    let sock = to_net_socket("  49: 0100007F:1132 5B41EE2E:0050 0A 0000000A:00000002 00:00000000 00000000  1001        0 2796814 1 ffff938ed0741080 20 4 29 10 -1");
     assert_eq!(sock.local_address.octets(), [127, 0, 0, 1]);
     assert_eq!(sock.local_port, 4402);
     assert_eq!(sock.remote_address.octets(), [46, 238, 65, 91]);
     assert_eq!(sock.remote_port, 80);
     assert_eq!(sock.state, SocketState::Listen);
-    assert_eq!(sock.tx_queue, 1);
+    assert_eq!(sock.tx_queue, 0xA);
     assert_eq!(sock.rx_queue, 2);
     assert_eq!(sock.timer, SocketTimerState::Inactive);
     assert_eq!(sock.uid, 1001);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub struct MemInfo {
 
 enum_from_primitive! {
     /// Represents TCP socket's state.
-    #[derive(Clone, Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
     pub enum SocketState {
         Established = 1,
         SynSent = 2,


### PR DESCRIPTION
o/

This change implements parsing `/proc/net/{tcp,udp}`, together with the relevant data types. It also features a small refactor that uses Rust's `std::fs` instead of spawning `cat` for reading other `/proc` files (it's the last commit, feel free to discard if there's a reason for using `cat` there!).

The use-case here is that we're rewriting our monitoring agent, [`forza`](https://github.com/npm/forza) in Rust and wanted to track the number of sockets in different states (this metric has proven really useful to us in the past).